### PR TITLE
reenable ffmpeg back pressure (works for me)

### DIFF
--- a/lib/video/PngEncoder.js
+++ b/lib/video/PngEncoder.js
@@ -1,8 +1,6 @@
 // Converts a video stream into a stream of png buffers. Each 'data' event
 // is guaranteed to contain exactly 1 png image.
 
-// @TODO Figure out why ffmpeg.stdin.write seems to always return false and
-// never emits 'drain' event (so we can get backpressure working)
 // @TODO handle ffmpeg exit (and trigger "error" if unexpected)
 
 var Stream      = require('stream').Stream;
@@ -33,7 +31,7 @@ PngEncoder.prototype.write = function(buffer) {
     this._initFfmpegAndPipes();
   }
 
-  this._ffmpeg.stdin.write(buffer);
+  return this._ffmpeg.stdin.write(buffer);
 };
 
 PngEncoder.prototype._initFfmpegAndPipes = function() {
@@ -51,6 +49,8 @@ PngEncoder.prototype._initFfmpegAndPipes = function() {
   // 'error' can be EPIPE if ffmpeg does not exist. We handle this with the
   // 'exit' event below.
   this._ffmpeg.stdin.on('error', function() {});
+
+  this._ffmpeg.stdin.on('drain', this.emit.bind(this, 'drain'));
 
   var self = this;
   this._ffmpeg.on('exit', function(code) {

--- a/test/unit/video/test-PngEncoder.js
+++ b/test/unit/video/test-PngEncoder.js
@@ -167,10 +167,21 @@ test('PngEncoder', {
     assert.strictEqual(stdin.write.getCall(1).args[0], this.fakeBuffer2);
   },
 
-  'write() does not handle ffmpeg backpressure for now': function() {
+  'write() handles ffmpeg backpressure': function() {
     this.fakeFfmpeg.stdin.write.returns(true);
     var r = this.encoder.write(new Buffer('abc'));
-    assert.equal(r, undefined);
+    assert.equal(r, true);
+
+    this.fakeFfmpeg.stdin.write.returns(false);
+    r = this.encoder.write(new Buffer('abc'));
+    assert.equal(r, false);
+
+    var drainCalled = false;
+    this.encoder.on('drain', function () {
+        drainCalled = true;
+    });
+    this.fakeFfmpeg.stdin.emit('drain');
+    assert.ok(drainCalled);
   },
 
   'write() pipes ffmpeg stderr to log': function() {


### PR DESCRIPTION
At least for me (OSX 10.7.5, node v0.8.9, ffmpeg 0.11.1.git-1ad63ff) stdin of the ffmpeg spawn gives both true/false on write as well as drain events.  Am I the only one?
