### PR TITLE
changed altitude conversion

### DIFF
--- a/lib/navdata/parseNavdata.js
+++ b/lib/navdata/parseNavdata.js
@@ -61,7 +61,7 @@ exports.OPTION_PARSERS = {
       frontBackDegrees  : reader.float32() / 1000,
       leftRightDegrees  : reader.float32() / 1000,
       clockwiseDegrees  : reader.float32() / 1000,
-      altitudeMeters    : reader.uint32() / 100,
+      altitudeMeters    : reader.uint32() / 1000,
 
       // @TODO figure out what units those are
       xVelocity : reader.float32(),


### PR DESCRIPTION
changed the altitude-conversion to use millimeters instead of centimeters (fixes #15).

All tests still pass, which is unfortunate.

@felixge: how did you create the fixtures (`navdata.bin`), i would like to change the demo-fixture to contain an altitude different from zero.
