### PR TITLE
Add custom events

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -64,8 +64,10 @@ Client.prototype._handleNavdata = function(navdata) {
   }
 
   this.emit('navdata', navdata);
+  this._processNavdata(navdata);
+};
 
-  // custom navdata events
+Client.prototype._processNavdata = function(navdata) {
   if (navdata.droneState && navdata.demo) {
     // controlState events
     var cstate = navdata.demo.controlState;
@@ -77,7 +79,8 @@ Client.prototype._handleNavdata = function(navdata) {
     emitState('landing', 'CTRL_TRANS_LANDING');
     emitState('landed', 'CTRL_LANDED');
     emitState('takeoff', 'CTRL_TRANS_TAKEOFF');
-    emitState('flying', 'CTRL_HOVERING');
+    emitState('hovering', 'CTRL_HOVERING');
+    emitState('flying', 'CTRL_FLYING');
     this._lastState = cstate;
 
     // battery events
@@ -96,8 +99,8 @@ Client.prototype._handleNavdata = function(navdata) {
       this.emit('altitudeChange', altitude);
       this._lastAltitude = altitude;
     }
-
   }
+
 };
 
 // emits an 'error' event, but only if somebody is listening. This avoids

--- a/test/unit/test-Client.js
+++ b/test/unit/test-Client.js
@@ -84,10 +84,24 @@ test('Client', {
     this.fakeUdpNavdataStream.emit('data', fakeNavdataTakeoff);
     assert.equal(gotEventTakeoff, true);
 
+    // hovering event
+    var fakeNavdataHovering = {
+      droneState: 'navdata',
+      demo: {controlState: 'CTRL_HOVERING'}
+    };
+
+    var gotEventHovering;
+    this.client.on('hovering', function() {
+      gotEventHovering = true;
+    });
+
+    this.fakeUdpNavdataStream.emit('data', fakeNavdataHovering);
+    assert.equal(gotEventHovering, true);
+
     // flying event
     var fakeNavdataFlying = {
       droneState: 'navdata',
-      demo: {controlState: 'CTRL_HOVERING'}
+      demo: {controlState: 'CTRL_FLYING'}
     };
 
     var gotEventFlying;


### PR DESCRIPTION
This will make a drone client emit landing, landed, takeoff, flying, batteryChange, altitudeChange, and lowBattery events based on incoming navdata.

All of the tests pass but I'm not familiar with the testing framework so you might want to double check before pulling this in

Callbacks for .takeoff() and .land() could be implemented as easy as `this.once('landed', cb)`
