### PR TITLE
Proof of concept for calling FTRIM before `takeoff()`. 

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -137,6 +137,17 @@ Client.prototype.disableEmergency = function() {
 };
 
 Client.prototype.takeoff = function() {
+  this.ftrim();
+  var self = this;
+  setTimeout(function() {
+    console.log("Take-off");
+    self._ref.fly = true;
+  }, 5000);
+  return true;
+};
+
+Client.prototype.takeoffUnstable = function() {
+  console.log("Take-off Unstable");
   this._ref.fly = true;
   return true;
 };
@@ -157,6 +168,23 @@ Client.prototype.config = function(key, value) {
   var self = this;
   this._repeat(10, function() {
     self._udpControl.config(key, value);
+  });
+};
+
+
+Client.prototype.ftrim = function() {
+  // @TODO Figure out if we can get a ACK for this, so we don't need to
+  // repeat it blindly like this
+
+  if(this._ref.fly) {
+    console.log("You can’t ftrim when you fly");
+    return false;
+  }
+
+  var self = this;
+  console.log("Stabilizing…")
+  this._repeat(100, function() {
+    self._udpControl.ftrim();
   });
 };
 

--- a/lib/control/AtCommandCreator.js
+++ b/lib/control/AtCommandCreator.js
@@ -31,6 +31,11 @@ AtCommandCreator.prototype.ref = function(options) {
   return this.raw('REF', args);
 };
 
+// TMP: Used to send FTRIM
+AtCommandCreator.prototype.ftrim = function() {
+  this.raw('FTRIM');
+}
+
 // Used to fly the drone around
 AtCommandCreator.prototype.pcmd = function(options) {
   options = options || {};


### PR DESCRIPTION
(cleaned up version of #25)

Based on the Drone Manual:

> AT_FTRIM
> Summary : Flat trims - Tells the drone it is lying horizontally Corresponding API function : ardrone_at_set_flat_trim
> Syntax : AT_FTRIM=%d,<CR>
> Argument 1 : the sequence number
> Description :
> This command sets a reference of the horizontal plane for the drone internal control system.
> It must be called after each drone start up, while making sure the drone actually sits on a horizontal ground. Not doin\
> g so before taking-off will result in the drone not being able to stabilize itself when flying, as it would not be able t\
> o know its actual tilt. This command MUST NOT be sent when the AR.Drone is flying.
> When receiving this command, the drone will automatically adjust the trim on pitch and roll controls.
