### PR TITLE
Maintain a single png or tcp stream in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ is a simple way to get this as PngBuffers (requires a recent ffmpeg version to
 be found in your `$PATH`):
 
 ```js
-var pngStream = client.createPngStream();
+var pngStream = client.getPngStream();
 pngStream.on('data', console.log);
 ```
 
@@ -125,10 +125,17 @@ Returns a new `Client` object. `options` include:
 Launches an interactive interface with all client methods available in the
 active scope. Additionally `client` resolves to the `client` instance itself.
 
-#### client.createPngStream()
+#### client.getPngStream()
 
-Returns a `PngStream` object that emits individual png image buffers as `'data'`
-events.
+Returns a `PngEncoder` object that emits individual png image buffers as `'data'`
+events. Multiple calls to this method returns the same object. Connection lifecycle
+(e.g. reconnect on error) is managed by the client.
+
+#### client.getVideoStream()
+
+Returns a `TcpVideoStream` object that emits raw tcp packets as `'data'`
+events. Multiple calls to this method returns the same object. Connection lifecycle
+(e.g. reconnect on error) is managed by the client.
 
 #### client.takeoff(cb)
 

--- a/examples/png-stream.js
+++ b/examples/png-stream.js
@@ -5,7 +5,7 @@ var http    = require('http');
 
 console.log('Connecting png stream ...');
 
-var pngStream = arDrone.createPngStream();
+var pngStream = arDrone.createClient().getPngStream();
 
 var lastPng;
 pngStream

--- a/examples/tcp-video-stream.js
+++ b/examples/tcp-video-stream.js
@@ -1,14 +1,8 @@
 // Run this to receive the raw video stream from your drone as buffers.
 
-var TcpVideoStream = require('../lib/video/TcpVideoStream');
+var arDrone = require('..');
 
-var video = new TcpVideoStream();
-
-console.log('Connecting ...');
-video.connect(function(err) {
-  if (err) throw err;
-
-  console.log('Connected');
-});
+var video = arDrone.createClient().getVideoStream();
 
 video.on('data', console.log);
+video.on('error', console.log);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -5,6 +5,8 @@ Client.UdpControl       = require('./control/UdpControl');
 Client.Repl             = require('./Repl');
 Client.UdpNavdataStream = require('./navdata/UdpNavdataStream');
 Client.PngStream        = require('./video/PngStream');
+Client.PngEncoder       = require('./video/PngEncoder');
+Client.TcpVideoStream   = require('./video/TcpVideoStream');
 
 module.exports = Client;
 util.inherits(Client, EventEmitter);
@@ -13,9 +15,11 @@ function Client(options) {
 
   options = options || {};
 
+  this._options           = options;
   this._udpControl        = options.udpControl || new Client.UdpControl(options);
   this._udpNavdatasStream = options.udpNavdataStream || new Client.UdpNavdataStream(options);
-  this._pngStream         = new Client.PngStream(options);
+  this._pngStream         = null;
+  this._tcpStream         = null;
   this._interval          = null;
   this._ref               = {};
   this._pcmd              = {};
@@ -40,9 +44,51 @@ Client.prototype.createRepl = function() {
 };
 
 Client.prototype.createPngStream = function() {
-  this._pngStream.resume();
-  return this._pngStream;
+  console.warn("Client.createPngStream is deprecated. Use Client.getPngStream instead.");
+  return this.getPngStream();
 };
+
+Client.prototype.getPngStream = function() {
+  if (this._pngStream == null) {
+      this._pngStream = this._newPngStream();
+  }
+  return this._pngStream;
+}
+
+Client.prototype.getVideoStream = function() {
+  if (this._tcpVideoStream == null) {
+    this._tcpVideoStream = this._newTcpVideoStream();
+  }
+  return this._tcpVideoStream;
+}
+
+Client.prototype._newTcpVideoStream = function() {
+  var stream = new Client.TcpVideoStream(this._options);
+  var callback = function(err) {
+    if (err !== null) {
+      console.log('TcpVideoStream error: %s', err.message);
+      setTimeout(function () {
+          console.log('Attempting to reconnect to TcpVideoStream...');
+          stream.connect(callback);
+      }, 1000);
+    }
+  }
+
+  stream.connect(callback);
+  stream.on('error', callback);
+  return stream;
+}
+
+Client.prototype._newPngStream = function() {
+  var videoStream = this.getVideoStream();
+  var pngEncoder = new Client.PngEncoder(this._options);
+
+  videoStream.on('data', function(data) {
+      pngEncoder.write(data);
+  });
+
+  return pngEncoder;
+}    
 
 Client.prototype.resume = function() {
   // request basic navdata by default

--- a/lib/video/PngStream.js
+++ b/lib/video/PngStream.js
@@ -7,6 +7,7 @@ var util       = require('util');
 module.exports = PngStream;
 util.inherits(PngStream, Stream);
 function PngStream(options) {
+  console.warn('The PngStream class is deprecated. Use client.getPngStream() instead.');
   Stream.call(this);
 
   options = options || {};

--- a/lib/video/TcpVideoStream.js
+++ b/lib/video/TcpVideoStream.js
@@ -21,6 +21,7 @@ function TcpVideoStream(options) {
 TcpVideoStream.prototype.connect = function(cb) {
   cb = cb || function() {};
 
+  this._socket.removeAllListeners();                // To avoid duplicates when re-connecting
   this._socket.connect(this._port, this._ip);
   this._socket.setTimeout(this._timeout);
 

--- a/test/unit/test-Client.js
+++ b/test/unit/test-Client.js
@@ -3,7 +3,8 @@ var assert       = require('assert');
 var test         = require('utest');
 var sinon        = require('sinon');
 var Client       = require(common.lib + '/Client');
-var PngStream    = Client.PngStream;
+var PngEncoder   = Client.PngEncoder;
+var TcpVideoStream = Client.TcpVideoStream; 
 var EventEmitter = require('events').EventEmitter;
 
 test('Client', {
@@ -19,9 +20,13 @@ test('Client', {
     this.fakeUdpNavdataStream        = new EventEmitter;
     this.fakeUdpNavdataStream.resume = sinon.stub();
 
-    this.pngStream   = new PngStream();
-    Client.PngStream = sinon.stub();
-    Client.PngStream.returns(this.pngStream);
+    this.pngEncoder  = new PngEncoder();
+    Client.PngEncoder = sinon.stub();
+    Client.PngEncoder.returns(this.pngEncoder);
+    
+    this.tcpVideoStream  = new TcpVideoStream();
+    Client.TcpVideoStream = sinon.stub();
+    Client.TcpVideoStream.returns(this.tcpVideoStream);
 
     this.options = {
       udpControl       : this.fakeUdpControl,
@@ -393,16 +398,37 @@ test('Client', {
     assert.equal(args[1], 2000);
   },
 
-  'createPngStream resumes and returns internal pngStream': function() {
-    // check that the PngStream was constructed properly
-    assert.equal(Client.PngStream.callCount, 1);
-    assert.strictEqual(Client.PngStream.getCall(0).args[0], this.options);
+  'getPngStream creates and resume a single stream': function() {
+    sinon.stub(this.tcpVideoStream, 'connect');
 
-    sinon.stub(this.pngStream, 'resume');
+    var pngStream1 = this.client.getPngStream();
+    var pngStream2 = this.client.getPngStream();
 
-    var pngStream = this.client.createPngStream();
-    assert.equal(this.pngStream.resume.callCount, 1);
-    assert.strictEqual(pngStream, this.pngStream);
+    // check that the underlying TcpVideoStream and PngEncoder were constructed only once
+    assert.equal(Client.PngEncoder.callCount, 1);
+    assert.equal(Client.TcpVideoStream.callCount, 1);
+    assert.strictEqual(Client.TcpVideoStream.getCall(0).args[0], this.options);
+    assert.equal(this.tcpVideoStream.connect.callCount, 1);
+
+    // check returned streams are always the same
+    assert.strictEqual(pngStream1, this.pngEncoder);
+    assert.strictEqual(pngStream2, this.pngEncoder);
+  },
+  
+  'getTcpVideoStream creates and resume a single stream': function() {
+    sinon.stub(this.tcpVideoStream, 'connect');
+
+    var videoStream1 = this.client.getVideoStream();
+    var videoStream2 = this.client.getVideoStream();
+
+    // check that the PngStream was constructed only once
+    assert.equal(Client.TcpVideoStream.callCount, 1);
+    assert.strictEqual(Client.TcpVideoStream.getCall(0).args[0], this.options);
+    assert.equal(this.tcpVideoStream.connect.callCount, 1);
+
+    // check returned streams are always the same
+    assert.strictEqual(videoStream1, this.tcpVideoStream);
+    assert.strictEqual(videoStream2, this.tcpVideoStream);
   },
 
   'after methods are called in client context': function() {


### PR DESCRIPTION
Here is a first partial solution for issue #43 that is sufficient to solve some my problems. It should not break the current API and issues a warning for deprecation on the createPngStream method. 

However it is not a a complete solution, since the PngStream will instantiate its own TcpVideoStream, thus disconnecting any other stream obtained via getTcpVideoStream.

In addition, using any other module which directly manage its own tcpstream (e.g. node-dronestream) will also conflict and break everything. 

Feedback/comments welcome.
