### PR TITLE
Added an example on saving the video-stream

### DIFF
--- a/examples/save-video-stream.js
+++ b/examples/save-video-stream.js
@@ -1,0 +1,20 @@
+// Run this to save a h264 video file, with the PaVE frame filtered out.
+// You can then use this file as a ffmpeg source for additional processing
+// or streaming to a ffserver
+
+var arDrone = require('..');
+var PaVEParser = require('../lib/video/PaVEParser'); 
+var output = require('fs').createWriteStream('./vid.h264');
+
+var video = arDrone.createClient().getVideoStream();
+var parser = new PaVEParser();
+
+parser
+  .on('data', function(data) {
+    output.write(data.payload);
+  })
+  .on('end', function() {
+    output.end();
+  });
+
+video.pipe(parser);


### PR DESCRIPTION
As you can see, I can't just pipe the parser output to the file and need to process it to extract the payload. This relates to the discussion in Issue #17.
- I +1 for updating PaVE parser to make this example simpler, however this breaks two tests
- the new client.getVideoStream method could return a parsed stream, we could add a getRawVideoStream to get the unparsed version

Please comment and i'll update the pull requests with these changes based on your feedback
