### PR TITLE
Added calibrate command to UdpControl and Client

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -201,6 +201,10 @@ Client.prototype.stop = function() {
   return true;
 };
 
+Client.prototype.calibrate = function(device_num) {
+  this._udpControl.calibrate(device_num);
+};
+
 Client.prototype.config = function(key, value) {
   // @TODO Figure out if we can get a ACK for this, so we don't need to
   // repeat it blindly like this

--- a/lib/control/AtCommandCreator.js
+++ b/lib/control/AtCommandCreator.js
@@ -53,6 +53,12 @@ AtCommandCreator.prototype.pcmd = function(options) {
   return this.raw('PCMD', args);
 };
 
+AtCommandCreator.prototype.calibrate = function(device_num) {
+  var args = [device_num];
+
+  return this.raw('CALIB', args);
+};
+
 AtCommandCreator.prototype.config = function(name, value) {
   return this.raw('CONFIG', '"' + name + '"', '"' + value + '"');
 };

--- a/test/unit/control/test-AtCommandCreator.js
+++ b/test/unit/control/test-AtCommandCreator.js
@@ -70,6 +70,17 @@ test('AtCommandCreator', {
     assert.ok(cmd.args[0] & (1 << 0));
   },
 
+  'calibrate': function() {
+    var cmd = this.creator.calibrate(0);
+    assert.equal(cmd.type, 'CALIB');
+    assert.equal(cmd.args.length, 1);
+    assert.equal(cmd.args[0], '0');
+    cmd = this.creator.calibrate(1);
+    assert.equal(cmd.type, 'CALIB');
+    assert.equal(cmd.args.length, 1);
+    assert.equal(cmd.args[0], '1');
+  },
+
   'config': function() {
     var cmd = this.creator.config('foo', 'bar');
     assert.equal(cmd.type, 'CONFIG');


### PR DESCRIPTION
Added a new AT command, "CALIB", which according to the SDK docs "asks the drone to calibrate the magnetometer (must be flying)."

Tested from a repl.  Note that this causes the drone to yaw 360 degrees.

The command takes a single argument, which is a device number.  Currently the only device the SDK defines is the magnetometer, which is device number 0.
