### PR TITLE
vidionDetect -> oriantationAngle is a float32

### DIFF
--- a/lib/navdata/parseNavdata.js
+++ b/lib/navdata/parseNavdata.js
@@ -390,7 +390,7 @@ exports.OPTION_PARSERS = {
       width            : timesMap(4, reader.uint32, reader),
       height           : timesMap(4, reader.uint32, reader),
       dist             : timesMap(4, reader.uint32, reader),
-      orientationAngle : timesMap(4, reader.uint32, reader),
+      orientationAngle : timesMap(4, reader.float32, reader),
       rotation         : timesMap(4, reader.matrix33, reader),
       translation      : timesMap(4, reader.vector31, reader),
       cameraSource     : timesMap(4, reader.uint32, reader)


### PR DESCRIPTION
Fixed the oriantationAngle in order to get a proper value expressed in degree. Tested on real tag detection, works like a charm.
