### PR TITLE
Reduce time suggested for animating flip in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Performs a pre-programmed flight sequence for a given `duration` (in ms).
 Example:
 
 ```js
-client.animate('flipLeft', 1500);
+client.animate('flipLeft', 1000);
 ```
 
 Please note that the drone will need a good amount of altitude and headroom


### PR DESCRIPTION
Often I'll see the drone do two flips when passing 1500 to animate, reduced it down so that there is less chance of that happening by accident when users are just getting started.
