### PR TITLE
fix timeout errors on socket end

### DIFF
--- a/lib/video/TcpVideoStream.js
+++ b/lib/video/TcpVideoStream.js
@@ -21,7 +21,6 @@ function TcpVideoStream(options) {
 TcpVideoStream.prototype.connect = function(cb) {
   cb = cb || function() {};
 
-  this._socket.removeAllListeners();                // To avoid duplicates when re-connecting
   this._socket.connect(this._port, this._ip);
   this._socket.setTimeout(this._timeout);
 
@@ -51,6 +50,10 @@ TcpVideoStream.prototype.connect = function(cb) {
       var err = new Error('TcpVideoStream received FIN unexpectedly.');
       self.emit('error', err);
       self.emit('close', err);
+    })
+    .on('close', function () {
+        // To avoid duplicates when re-connecting
+        self.removeAllListeners();
     });
 };
 


### PR DESCRIPTION
Requesting comments on this one: removing _all_ listeners on the tcp video socket seems to break disconnection on recent node versions, since we also remove the internal listeners (namely the `finish` event). The effect is that closing a socket basically does nothing, until we catch a timeout error later on.

Lacking a drone, I couldn't verify that moving the removeAllListeners() call to the `close` handler is enough to have the desired effect for reusing the socket on reconnection. At least it doesn't break test anymore for me.
An alternative proposal (though less elegant) would be to only remove the listeners we add ourselves.

CC @eschnou, since you introduced the removeAllListeners() call, I'd love Your feedback on this issue.
