### PR TITLE
Stricter jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,5 +4,6 @@
   "indent": 2,
   "curly": true,
   "trailing": true,
-  "undef": true
+  "undef": true,
+  "unused": true
 }

--- a/lib/control/UdpControl.js
+++ b/lib/control/UdpControl.js
@@ -49,7 +49,7 @@ meta.methods(AtCommandCreator).forEach(function(methodName) {
   };
 });
 
-UdpControl.prototype.ack = function(ack) {
+UdpControl.prototype.ack = function() {
   if (this._blocked.state === states.WAITING_FOR_ACK) {
     assert(this._blocked.cmd);
     assert(this._blocked.ackTimer);

--- a/test/integration/video/TcpVideoStream/test-connection-timeout.js
+++ b/test/integration/video/TcpVideoStream/test-connection-timeout.js
@@ -3,8 +3,7 @@ var net            = require('net');
 var assert         = require('assert');
 var TcpVideoStream = require(common.lib + '/video/TcpVideoStream');
 
-var server = net.createServer(function(connection) {
-});
+var server = net.createServer(function() {});
 
 var events = [];
 server.listen(common.TCP_PORT, function() {

--- a/test/unit/control/test-UdpControl.js
+++ b/test/unit/control/test-UdpControl.js
@@ -64,7 +64,7 @@ test('UdpControl', {
       ip     : fakeIp,
     });
     var callback = sinon.spy();
-    var config = control.config('general:navdata_demo', 'TRUE', callback);
+    control.config('general:navdata_demo', 'TRUE', callback);
     control.flush();
     this.clock.tick(500);
     assert.equal(callback.callCount, 1);
@@ -83,7 +83,7 @@ test('UdpControl', {
       ip     : fakeIp,
     });
     var callback = sinon.spy();
-    var config = control.config('general:navdata_demo', 'TRUE', callback);
+    control.config('general:navdata_demo', 'TRUE', callback);
     control.flush();
     control.ack();
     control.ackReset();

--- a/test/unit/test-Client.js
+++ b/test/unit/test-Client.js
@@ -221,7 +221,7 @@ test('Client', {
     this.client.resume();
 
     var eventCount = 0;
-    this.client.on('navdata', function(navdata) {
+    this.client.on('navdata', function() {
       eventCount++;
     });
 
@@ -238,7 +238,7 @@ test('Client', {
       gotOptions = options;
     };
 
-    var client = new Client(options);
+    new Client(options);
     assert.strictEqual(gotOptions, options);
   },
 


### PR DESCRIPTION
Hey there,

I've set two other jshint options that I really like. One is more cosmetic ([unused](http://www.jshint.com/docs/options/#unused)), as it simply prevents variables laying around that no one uses, but the other one ([undef](http://www.jshint.com/docs/options/#undef)) can help detecting leaks.

I've fixed the code to comply to these rules as well. Wasn't that much fortunately.
