### PR TITLE
Allows client to specify 0 speed

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -269,7 +269,7 @@ var pcmdOptions = [
 
 pcmdOptions.forEach(function(pair) {
   Client.prototype[pair[0]] = function(speed) {
-    if (!speed) {
+    if (isNaN(speed)) {
       return;
     }
     speed = parseFloat(speed);
@@ -281,7 +281,7 @@ pcmdOptions.forEach(function(pair) {
   };
 
   Client.prototype[pair[1]] = function(speed) {
-    if (!speed) {
+    if (isNaN(speed)) {
       return;
     }
 

--- a/test/unit/test-Client.js
+++ b/test/unit/test-Client.js
@@ -314,12 +314,46 @@ test('Client', {
     assert.equal(this.client._pcmd.clockwise, undefined);
   },
 
-  'pcmd methods conver strings to floats': function() {
+  'pcmd methods convert strings to floats': function() {
     this.client.up('-0.5');
     assert.strictEqual(this.client._pcmd.up, -0.5);
 
     this.client.down('-0.5');
     assert.strictEqual(this.client._pcmd.down, -0.5);
+  },
+
+  'pcmd methods accept 0 as speed': function() {
+    this.client.up(0);
+    assert.equal(this.client._pcmd.up, 0);
+    assert.equal(this.client._pcmd.down, undefined);
+
+    this.client.down(0);
+    assert.equal(this.client._pcmd.down, 0);
+    assert.equal(this.client._pcmd.up, undefined);
+
+    this.client.left(0);
+    assert.equal(this.client._pcmd.left, 0);
+    assert.equal(this.client._pcmd.right, undefined);
+
+    this.client.right(0);
+    assert.equal(this.client._pcmd.right, 0);
+    assert.equal(this.client._pcmd.left, undefined);
+
+    this.client.front(0);
+    assert.equal(this.client._pcmd.front, 0);
+    assert.equal(this.client._pcmd.back, undefined);
+
+    this.client.back(0);
+    assert.equal(this.client._pcmd.back, 0);
+    assert.equal(this.client._pcmd.front, undefined);
+
+    this.client.clockwise(0);
+    assert.equal(this.client._pcmd.clockwise, 0);
+    assert.equal(this.client._pcmd.counterClockwise, undefined);
+
+    this.client.counterClockwise(0);
+    assert.equal(this.client._pcmd.counterClockwise, 0);
+    assert.equal(this.client._pcmd.clockwise, undefined);
   },
 
   'pcmd checks if argument exists': function() {


### PR DESCRIPTION
#### Background story

I have a Logitech rumblepad2 for which I've written [an interface with node-ar-drone](https://github.com/michaelshmitty/drone-gamepad) to control my AR drone 2.0.
The joystick controls pitch and roll, the dpad controls yaw, ascend and descend.
When the joystick is centered, pitch and roll should stop.
When a dpad button is released, yaw, ascend, descend should stop.

At first I used client.stop(), but that stops all movement. I didn't want my yaw movement (dpad) to stop whenever I stopped pitching / rolling (joystick).
Instead I let my code figure out what movement should be stopped specifically and set speed to 0 for that movement.
#### Speed of 0 ignored

Then I noticed client.front(0) was being ignored by the node-ar-drone library. I investigated and wrote this fix with a test. My gamepad now works as expected, yay.
