### PR TITLE
This should allow Travis builds to now pass.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
+  - "8"
+  - "7"
+  - "6"


### PR DESCRIPTION
There was possible a BOM character at the begining of the package.json. The best fix is to tell Travis to use a more up to date version of npm and node. As 0.6 is ancient!